### PR TITLE
Make exec-path-from-shell optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ M-x customize-group RET aweshell RET
 aweshell-complete-selection-key
 aweshell-clear-buffer-key
 aweshell-sudo-toggle-key
+aweshell-use-exec-path-from-shell
 ```
 
 Customize prompt as directed in [eshell-prompt-extras' README](https://github.com/kaihaosw/eshell-prompt-extras#themes).

--- a/aweshell.el
+++ b/aweshell.el
@@ -86,12 +86,15 @@
 ;;
 ;; `aweshell-valid-command-color'
 ;; `aweshell-invalid-command-color'
+;; `aweshell-use-exec-path-from-shell'
 ;;
 ;; All of the above can customize by:
 ;;      M-x customize-group RET aweshell RET
 ;;
 
 ;;; Change log:
+;; 2018/09/19
+;;      * Make `exec-path-from-shell' optional. Disable with variable`aweshell-use-exec-path-from-shell'.
 ;;
 ;; 2018/09/17
 ;;      * Use `ido-completing-read' instead `completing-read' to provide fuzz match.
@@ -152,7 +155,8 @@
 ;;; Code:
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; OS Config ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-(when (featurep 'cocoa)
+(when (and aweshell-use-exec-path-from-shell
+           (featurep 'cocoa))
   ;; Initialize environment from user's shell to make eshell know every PATH by other shell.
   (require 'exec-path-from-shell)
   (exec-path-from-shell-initialize))
@@ -162,6 +166,10 @@
   "Multi eshell manager."
   :group 'aweshell)
 
+(defcustom aweshell-use-exec-path-from-shell t
+  "Whether to use `exec-path-from-shell' to set PATH variable."
+  :type 'boolean
+  :group aweshell)
 (defcustom aweshell-complete-selection-key "M-h"
   "The keystroke for complete history auto-suggestions."
   :type 'string


### PR DESCRIPTION
This PR doesn't change any default behavior.

Add variable `aweshell-use-exec-path-from-shell`, defaults to `t`.

`exec-path-from-shell` is pretty slow, and I have my path configured elsewhere.