### PR TITLE
Fix toggle

### DIFF
--- a/aweshell.el
+++ b/aweshell.el
@@ -261,7 +261,8 @@
   "Toggle Aweshell."
   (interactive)
   (if (equal major-mode 'eshell-mode)
-      (switch-to-prev-buffer)
+      (while (equal major-mode 'eshell-mode)
+        (switch-to-prev-buffer))
     (aweshell-next)))
 
 (defun aweshell-new ()


### PR DESCRIPTION
Previously the toggle command doesn't return to normal buffer when there are multiple aweshell buffers.

Now it's fixed.