### PR TITLE
Add support of checking elisp functions to `aweshell-validate-command' 

### DIFF
--- a/aweshell.el
+++ b/aweshell.el
@@ -408,7 +408,9 @@ Create new one if no eshell buffer exists."
                            (equal command ".")
                            (equal command "exit"))
                        ;; Or it is a file in current dir?
-                       (member (file-name-base command) (directory-files default-directory)))
+                       (member (file-name-base command) (directory-files default-directory))
+                       ;; Or it is a elisp function
+                       (functionp (intern command)))
                       aweshell-valid-command-color
                     aweshell-invalid-command-color)))
         (put-text-property beg end 'rear-nonsticky t)))))


### PR DESCRIPTION
Sometimes I will use elisp fuction as a command in eshell, this commit can help check the command you typed  whether is a legal elisp function or not.

BTW, in my windows system I found that the function `aweshell-validate-command` cannot detect the
`cd` command. it will show the `cd` is an illegal command because i don't have `cd.exe` explicitly in my
`$PATH` environment variables, it's strange that because `cd` should be a built-in command of eshell.
this commit will also fix it (by recognizing `cd` as a elisp function) 