### PR TITLE
Handle prefix argument correctly

### DIFF
--- a/aweshell.el
+++ b/aweshell.el
@@ -281,7 +281,7 @@ If called with prefix argument, open Aweshell buffer in current directory when t
       (while (equal major-mode 'eshell-mode)
         (switch-to-prev-buffer))
     ;; toggle on
-    (if arg
+    (if (eq arg 4)
         ;; open in current dir
         (let* ((dir default-directory)
                (existing-buffer


### PR DESCRIPTION
1 instead of nil is passed to arg when there is no prefix argument,
making my code invalid when there is no prefix argument.
Now it is fixed

Sorry, I don't know prefix argument passes 1 instead of nil.