### PR TITLE
bugfix: replace 'esh-parse-shell-history'

### DIFF
--- a/aweshell.el
+++ b/aweshell.el
@@ -392,7 +392,7 @@ Create new one if no eshell buffer exists."
   (save-excursion
     (let* ((start-pos (eshell-beginning-of-input))
            (input (eshell-get-old-input))
-           (all-shell-history (esh-parse-shell-history)))
+           (all-shell-history (aweshell-parse-shell-history)))
       (let* ((command (ido-completing-read "Search history: " all-shell-history)))
         (eshell-kill-input)
         (insert command)


### PR DESCRIPTION
Replace 'esh-parse-shell-history' with 'aweshell-parse-shell-history', it looks like 'esh-parse-shell-history' has been deleted.