### PR TITLE
feature: add `aweshell-switch-buffer'

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ aweshell-next
 aweshell-prev
 aweshell-clear-buffer
 aweshell-sudo-toggle
+aweshell-switch-buffer
 ```
 
 # Customize


### PR DESCRIPTION
Switch to another aweshell buffer.
Preselect the closest aweshell to the `default-directory' of the current buffer