### PR TITLE
fix(aweshell-validate-command): beginning-of-line conflict with eshell-prompt-regexp

### DIFF
--- a/aweshell.el
+++ b/aweshell.el
@@ -601,9 +601,7 @@ This advice can make `other-window' skip `aweshell' dedicated window."
 (defun aweshell-validate-command ()
   (save-excursion
     (beginning-of-line)
-    (re-search-forward (format "%s\\([^ \t\r\n\v\f]*\\)" eshell-prompt-regexp)
-                       (line-end-position)
-                       t)
+    (re-search-forward  "\\([^ \t\r\n\v\f]*\\)" (line-end-position) t)
     (let ((beg (match-beginning 1))
           (end (match-end 1))
           (command (match-string 1)))


### PR DESCRIPTION
![t](https://user-images.githubusercontent.com/17718104/72049459-f365c500-32f9-11ea-8882-9ab1468225f6.gif)
