### PR TITLE
fix(aweshell-validate-command): replace (beginning-of-line) with (forward-line 0)

### DIFF
--- a/aweshell.el
+++ b/aweshell.el
@@ -600,7 +600,7 @@ This advice can make `other-window' skip `aweshell' dedicated window."
 ;; Validate command before post to eshell.
 (defun aweshell-validate-command ()
   (save-excursion
-    (beginning-of-line)
+    (forward-line 0)
     (re-search-forward (format "%s\\([^ \t\r\n\v\f]*\\)" eshell-prompt-regexp)
                        (line-end-position)
                        t)


### PR DESCRIPTION
#46  will cause new bug，since no restrictions of prompt existing. The correct way is replace (beginning-of-line) with function skipping  field boundary.