### PR TITLE
fix(aweshell-validate-command): (line-end-position) can't move across field boundary

### DIFF
--- a/aweshell.el
+++ b/aweshell.el
@@ -600,10 +600,11 @@ This advice can make `other-window' skip `aweshell' dedicated window."
 ;; Validate command before post to eshell.
 (defun aweshell-validate-command ()
   (save-excursion
-    (forward-line 0)
-    (re-search-forward (format "%s\\([^ \t\r\n\v\f]*\\)" eshell-prompt-regexp)
-                       (line-end-position)
-                       t)
+    (let (end (line-end-position))
+      (forward-line 0)
+      (re-search-forward (format "%s\\([^ \t\r\n\v\f]*\\)" eshell-prompt-regexp)
+                         end
+                         t))
     (let ((beg (match-beginning 1))
           (end (match-end 1))
           (command (match-string 1)))


### PR DESCRIPTION
In #47 I was so stupid to forget function `(line-end-position)` which can't get position across the field boundary too. I din't find alternative  one [here](https://www.gnu.org/software/emacs/manual/html_node/elisp/Text-Lines.html), so i use local variable instead.