### PR TITLE
fix(cat): remove the read-only property before inserting

### DIFF
--- a/aweshell.el
+++ b/aweshell.el
@@ -760,7 +760,9 @@ This advice can make `other-window' skip `aweshell' dedicated window."
            (font-lock-ensure)
          (with-no-warnings
            (font-lock-fontify-buffer)))
-       (buffer-string)))
+       (let ((contents (buffer-string)))
+             (remove-text-properties 0 (length contents) '(read-only nil) contents)
+             contents)))
     (unless existing-buffer
       (kill-buffer buffer))
     nil))


### PR DESCRIPTION
Otherwise, eshell output filters (or, well, something) raises an error when inserting text with the read-only property. With this change, `cat my-image.png` works.

Note: This could be something particular to my setup, I'm not sure. All I know is that with this, `cat some-image.png` works and without it, it doesn't.